### PR TITLE
Add support for help text

### DIFF
--- a/System/Metrics/Prometheus.hs
+++ b/System/Metrics/Prometheus.hs
@@ -92,7 +92,6 @@ module System.Metrics.Prometheus
 import Data.Coerce (coerce)
 import qualified Data.HashMap.Strict as HM
 import Data.Kind (Type)
-import qualified Data.Map.Strict as M
 import Data.Proxy
 import qualified Data.Text as T
 import GHC.Generics
@@ -102,6 +101,7 @@ import qualified System.Metrics.Prometheus.Counter as Counter
 import qualified System.Metrics.Prometheus.Gauge as Gauge
 import System.Metrics.Prometheus.Histogram (HistogramSample)
 import qualified System.Metrics.Prometheus.Histogram as Histogram
+import qualified System.Metrics.Prometheus.Internal.Map2 as M2
 import qualified System.Metrics.Prometheus.Internal.Store as Internal
 
 -- $overview
@@ -547,7 +547,12 @@ class RegisterGroup (xs :: [Type]) where
 -- | Base case
 instance RegisterGroup '[] where
   registerGroup_ getters SamplingGroup sample =
-    Registration $ Internal.registerGroup (M.fromList getters) sample
+    let getterMap =
+          M2.fromList $
+            flip map getters $
+              \(Internal.Identifier name labels, sampler) ->
+                (name, labels, sampler)
+     in Registration $ Internal.registerGroup getterMap sample
 
 -- | Inductive case
 instance

--- a/System/Metrics/Prometheus/Example.hs
+++ b/System/Metrics/Prometheus/Example.hs
@@ -17,11 +17,17 @@ import qualified System.Metrics.Prometheus.Gauge as Gauge
 import System.Metrics.Prometheus
 
 -- Custom type describing a set of classes of metrics.
-data MyMetrics (name :: Symbol) (t :: MetricType) (labels :: Type) where
+data MyMetrics ::
+  Symbol -> -- Name
+  Symbol -> -- Help
+  MetricType ->
+  Type -> -- Labels
+  Type
+  where
   Requests ::
-    MyMetrics "requests" 'CounterType EndpointLabels
+    MyMetrics "requests" "" 'CounterType EndpointLabels
   DBConnections ::
-    MyMetrics "postgres.total_connections" 'GaugeType DataSourceLabels
+    MyMetrics "postgres.total_connections" "" 'GaugeType DataSourceLabels
 
 -- Custom label set
 newtype EndpointLabels = EndpointLabels { endpoint :: T.Text }

--- a/System/Metrics/Prometheus/GroupExample.hs
+++ b/System/Metrics/Prometheus/GroupExample.hs
@@ -11,9 +11,15 @@ import GHC.Stats
 import GHC.TypeLits (Symbol)
 import System.Metrics.Prometheus
 
-data RTSMetrics (name :: Symbol) (t :: MetricType) (labels :: Type) where
-  RTSGcs :: RTSMetrics "gcs" 'CounterType ()
-  RTSMaxLiveBytes :: RTSMetrics "max_live_bytes" 'GaugeType ()
+data RTSMetrics ::
+  Symbol -> -- Name
+  Symbol -> -- Help
+  MetricType ->
+  Type -> -- Labels
+  Type
+  where
+  RTSGcs :: RTSMetrics "gcs" "" 'CounterType ()
+  RTSMaxLiveBytes :: RTSMetrics "max_live_bytes" "" 'GaugeType ()
 
 main :: IO ()
 main = do

--- a/System/Metrics/Prometheus/Internal/Map2.hs
+++ b/System/Metrics/Prometheus/Internal/Map2.hs
@@ -1,17 +1,15 @@
--- | Helper functions for maps of maps.
+{-# OPTIONS_HADDOCK hide #-}
+
+-- | Helper functions for working with maps of maps.
 module System.Metrics.Prometheus.Internal.Map2
     ( fromList
-    , insert
     , delete
     , nonEmptyMap
     , lookup
-    , member
-    , keys
     ) where
 
 import Data.List (foldl')
 import qualified Data.Map.Strict as M
-import Data.Maybe (isJust)
 import Prelude hiding (lookup)
 
 fromList :: (Ord k1, Ord k2) => [(k1, k2, a)] -> M.Map k1 (M.Map k2 a)
@@ -43,13 +41,3 @@ nonEmptyMap m
 lookup
   :: (Ord k1, Ord k2) => k1 -> k2 -> M.Map k1 (M.Map k2 a) -> Maybe a
 lookup k1 k2 m = M.lookup k1 m >>= M.lookup k2
-
-member ::
-  (Ord k1, Ord k2) => k1 -> k2 -> M.Map k1 (M.Map k2 a) -> Bool
-member k1 k2 m = isJust $ lookup k1 k2 m
-
-keys :: M.Map k1 (M.Map k2 a) -> [(k1, k2)]
-keys m1 = do
-  (k1, m2) <- M.toList m1
-  k2 <- M.keys m2
-  pure (k1, k2)

--- a/System/Metrics/Prometheus/Internal/Map2.hs
+++ b/System/Metrics/Prometheus/Internal/Map2.hs
@@ -1,0 +1,55 @@
+-- | Helper functions for maps of maps.
+module System.Metrics.Prometheus.Internal.Map2
+    ( fromList
+    , insert
+    , delete
+    , nonEmptyMap
+    , lookup
+    , member
+    , keys
+    ) where
+
+import Data.List (foldl')
+import qualified Data.Map.Strict as M
+import Data.Maybe (isJust)
+import Prelude hiding (lookup)
+
+fromList :: (Ord k1, Ord k2) => [(k1, k2, a)] -> M.Map k1 (M.Map k2 a)
+fromList =
+  foldl'
+    (\m (name, labels, a) -> insert name labels a m)
+    M.empty
+
+insert
+  :: (Ord k1, Ord k2)
+  => k1 -> k2 -> a -> M.Map k1 (M.Map k2 a) -> M.Map k1 (M.Map k2 a)
+insert k1 k2 a = M.alter insert_ k1
+  where
+    insert_ Nothing = Just $ M.singleton k2 a
+    insert_ (Just m) = Just $ M.insert k2 a m
+
+-- | Delete a key from a map-within-a-map. If this would cause the map
+-- to become empty, remove the map.
+delete
+  :: (Ord k1, Ord k2)
+  => k1 -> k2 -> M.Map k1 (M.Map k2 a) -> M.Map k1 (M.Map k2 a)
+delete k1 k2 = M.update (nonEmptyMap . M.delete k2) k1
+
+nonEmptyMap :: M.Map k a -> Maybe (M.Map k a)
+nonEmptyMap m
+  | M.null m = Nothing
+  | otherwise = Just m
+
+lookup
+  :: (Ord k1, Ord k2) => k1 -> k2 -> M.Map k1 (M.Map k2 a) -> Maybe a
+lookup k1 k2 m = M.lookup k1 m >>= M.lookup k2
+
+member ::
+  (Ord k1, Ord k2) => k1 -> k2 -> M.Map k1 (M.Map k2 a) -> Bool
+member k1 k2 m = isJust $ lookup k1 k2 m
+
+keys :: M.Map k1 (M.Map k2 a) -> [(k1, k2)]
+keys m1 = do
+  (k1, m2) <- M.toList m1
+  k2 <- M.keys m2
+  pure (k1, k2)

--- a/System/Metrics/Prometheus/Internal/Sample.hs
+++ b/System/Metrics/Prometheus/Internal/Sample.hs
@@ -1,0 +1,55 @@
+{-# OPTIONS_HADDOCK hide #-}
+
+-- | Helper functions for working with metric samples.
+module System.Metrics.Prometheus.Internal.Sample
+    ( fromList
+    , insert
+    , delete
+    , lookup
+    , member
+    ) where
+
+import Data.List (foldl')
+import qualified Data.Map.Strict as M
+import Data.Maybe (isJust)
+import Prelude hiding (lookup)
+
+fromList :: (Ord k1, Ord k2) => [(k1, k2, a, b)] -> M.Map k1 (a, M.Map k2 b)
+fromList =
+  foldl'
+    (\m (k1, k2, a, b) -> insert k1 k2 a b m)
+    M.empty
+
+insert
+  :: (Ord k1, Ord k2)
+  => k1
+  -> k2
+  -> a
+  -> b
+  -> M.Map k1 (a, M.Map k2 b)
+  -> M.Map k1 (a, M.Map k2 b)
+insert k1 k2 a b = M.alter insert_ k1
+  where
+    insert_ Nothing = Just $ (a, M.singleton k2 b)
+    insert_ (Just (_, m)) = Just $ (a, M.insert k2 b m) -- Replace 'a'
+
+-- | Delete a key from a sample. If this would cause a map to become empty,
+-- remove it.
+delete
+  :: (Ord k1, Ord k2)
+  => k1 -> k2 -> M.Map k1 (a, M.Map k2 b) -> M.Map k1 (a, M.Map k2 b)
+delete k1 k2 = M.update (traverse (nonEmptyMap . M.delete k2)) k1
+
+nonEmptyMap :: M.Map k a -> Maybe (M.Map k a)
+nonEmptyMap m
+  | M.null m = Nothing
+  | otherwise = Just m
+
+lookup
+  :: (Ord k1, Ord k2) => k1 -> k2 -> M.Map k1 (a, M.Map k2 b) -> Maybe b
+lookup k1 k2 m = M.lookup k1 m >>= M.lookup k2 . snd
+
+member ::
+  (Ord k1, Ord k2) => k1 -> k2 -> M.Map k1 (a, M.Map k2 b) -> Bool
+member k1 k2 m = isJust $ lookup k1 k2 m
+

--- a/System/Metrics/Prometheus/Internal/Store.hs
+++ b/System/Metrics/Prometheus/Internal/Store.hs
@@ -153,7 +153,8 @@ registerGeneric identifier sample = Registration $ \state0 ->
     in  (state1, (:) handle)
 
 registerGroup
-    :: M.Map Identifier (a -> Value) -- ^ Metric names and getter functions
+    :: M.Map Name (M.Map Labels (a -> Value))
+        -- ^ Metric names and getter functions
     -> IO a -- ^ Action to sample the metric group
     -> Registration -- ^ Registration action
 registerGroup getters cb = Registration $ \state0 ->

--- a/System/Metrics/Prometheus/SimpleExample.hs
+++ b/System/Metrics/Prometheus/SimpleExample.hs
@@ -14,8 +14,14 @@ import qualified System.Metrics.Prometheus.Counter as Counter
 
 -- A user-specified GADT statically determines the names, types, and
 -- possible labels of the metrics that can be registered to the store.
-data AppMetrics (name :: Symbol) (t :: MetricType) (labels :: Type) where
-    RequestCount :: AppMetrics "myapp.request_count" 'CounterType ()
+data AppMetrics ::
+  Symbol -> -- Name
+  Symbol -> -- Help
+  MetricType ->
+  Type -> -- Labels
+  Type
+  where
+    RequestCount :: AppMetrics "myapp.request_count" "" 'CounterType ()
 
 main :: IO ()
 main = do

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -135,8 +135,8 @@ app1 = do
 
   -- Verify the sample, just for this tutorial.
   let expectedSample = M.fromList
-        [ (Identifier "my_app.requests" HM.empty, Counter 1)
-        , (Identifier "my_app.connections" HM.empty, Gauge 99)
+        [ ("my_app.requests", M.singleton HM.empty (Counter 1))
+        , ("my_app.connections", M.singleton HM.empty (Gauge 99))
         ]
   assert (sample == expectedSample) $ pure ()
 ```
@@ -264,22 +264,20 @@ app2 = do
   sample <- sampleAll store
 
   let expectedSample = M.fromList
-        [ ( Identifier
-              { idName = "requests"
-              , idLabels = HM.singleton "endpoint" "dev/harpsichord" }
-          , Counter 0
+        [ ( "requests"
+          , M.fromList
+            [ (HM.singleton "endpoint" "dev/harpsichord", Counter 0)
+            , (HM.singleton "endpoint" "dev/tabla", Counter 1)
+            ]
           )
-        , ( Identifier
-              { idName = "requests"
-              , idLabels = HM.singleton "endpoint" "dev/tabla" }
-          , Counter 1
-          )
-        , ( Identifier
-              { idName = "total_connections"
-              , idLabels = HM.fromList
-                  [ ("source_name", "myDB")
-                  , ("conn_info", "localhost:5432") ] }
-          , Gauge 99
+        , ( "total_connections"
+          , M.singleton
+              ( HM.fromList
+                [ ("source_name", "myDB")
+                , ("conn_info", "localhost:5432")
+                ]
+              )
+              (Gauge 99)
           )
         ]
   assert (sample == expectedSample) $ pure ()
@@ -325,8 +323,8 @@ app3 = do
 
   sample1 <- sampleAll store
   let expectedSample1 = M.fromList
-        [ (Identifier "my_app.requests" HM.empty, Counter 1)
-        , (Identifier "my_app.connections" HM.empty, Gauge 99)
+        [ ("my_app.requests", M.singleton HM.empty (Counter 1))
+        , ("my_app.connections", M.singleton HM.empty (Gauge 99))
         ]
   assert (sample1 == expectedSample1) $ pure ()
 
@@ -338,8 +336,8 @@ app3 = do
 
   sample2 <- sampleAll store
   let expectedSample2 = M.fromList
-        [ (Identifier "my_app.requests" HM.empty, Counter 1)
-        , (Identifier "my_app.connections" HM.empty, Gauge 5)
+        [ ("my_app.requests", M.singleton HM.empty (Counter 1))
+        , ("my_app.connections", M.singleton HM.empty (Gauge 5))
         ]
   assert (sample2 == expectedSample2) $ pure ()
 
@@ -347,9 +345,9 @@ app3 = do
   deregistrationHandle -- (2)
 
   sample3 <- sampleAll store
-  let expectedSample3 = M.fromList
-        [ (Identifier "my_app.connections" HM.empty, Gauge 5)
-        ]
+  let expectedSample3 =
+        M.singleton "my_app.connections" $
+          M.singleton HM.empty (Gauge 5)
   assert (sample3 == expectedSample3) $ pure ()
 ```
 

--- a/ekg-prometheus.cabal
+++ b/ekg-prometheus.cabal
@@ -44,6 +44,7 @@ library
     System.Metrics.Prometheus.Gauge
     System.Metrics.Prometheus.Histogram
     System.Metrics.Prometheus.Internal.Map2
+    System.Metrics.Prometheus.Internal.Sample
     System.Metrics.Prometheus.Internal.State
     System.Metrics.Prometheus.Internal.Store
 

--- a/ekg-prometheus.cabal
+++ b/ekg-prometheus.cabal
@@ -43,6 +43,7 @@ library
     System.Metrics.Prometheus.Export
     System.Metrics.Prometheus.Gauge
     System.Metrics.Prometheus.Histogram
+    System.Metrics.Prometheus.Internal.Map2
     System.Metrics.Prometheus.Internal.State
     System.Metrics.Prometheus.Internal.Store
 

--- a/test/Export.hs
+++ b/test/Export.hs
@@ -61,15 +61,28 @@ tests =
       store
   for_ (4:upperBounds) (Histogram.observe histogram)
 
-  prometheusSample <- BB.toLazyByteString . sampleToPrometheus <$> sampleAll store
+  prometheusSample <-
+    BB.toLazyByteString . sampleToPrometheus <$> sampleAll store
 
   shouldBe prometheusSample
-    "# TYPE _100gauge gauge\n_100gauge 100.0\n\n# TYPE my_counter counter\nmy_counter{label_name_2=\"label value 1\",label_name_1=\"label value 1\"} 10.0\nmy_counter{label_name_2=\"label value 2\",label_name_1=\"label value 2\"} 11.0\n\n# TYPE my_histogram histogram\nmy_histogram_bucket{le=\"1.0\",label_name=\"label_value\"} 1\nmy_histogram_bucket{le=\"2.0\",label_name=\"label_value\"} 2\nmy_histogram_bucket{le=\"3.0\",label_name=\"label_value\"} 3\nmy_histogram_bucket{le=\"+Inf\",label_name=\"label_value\"} 4\nmy_histogram_sum{label_name=\"label_value\"} 10.0\nmy_histogram_count{label_name=\"label_value\"} 4\n"
+    "# HELP _100gauge Example gauge\n# TYPE _100gauge gauge\n_100gauge 100.0\n\n# HELP my_counter Example counter\n# TYPE my_counter counter\nmy_counter{label_name_2=\"label value 1\",label_name_1=\"label value 1\"} 10.0\nmy_counter{label_name_2=\"label value 2\",label_name_1=\"label value 2\"} 11.0\n\n# HELP my_histogram Example histogram\n# TYPE my_histogram histogram\nmy_histogram_bucket{le=\"1.0\",label_name=\"label_value\"} 1\nmy_histogram_bucket{le=\"2.0\",label_name=\"label_value\"} 2\nmy_histogram_bucket{le=\"3.0\",label_name=\"label_value\"} 3\nmy_histogram_bucket{le=\"+Inf\",label_name=\"label_value\"} 4\nmy_histogram_sum{label_name=\"label_value\"} 10.0\nmy_histogram_count{label_name=\"label_value\"} 4\n"
 
-data ExampleMetrics :: Symbol -> MetricType -> Type -> Type where
-  ExampleGauge
-    :: ExampleMetrics "100gauge" 'GaugeType ()
-  ExampleCounter
-    :: ExampleMetrics "my.counter" 'CounterType (M.HashMap T.Text T.Text)
-  ExampleHistogram
-    :: ExampleMetrics "my.histogram" 'HistogramType (M.HashMap T.Text T.Text)
+data ExampleMetrics :: Symbol -> Symbol -> MetricType -> Type -> Type where
+  ExampleGauge ::
+    ExampleMetrics
+      "100gauge"
+      "Example gauge"
+      'GaugeType
+      ()
+  ExampleCounter ::
+    ExampleMetrics
+      "my.counter"
+      "Example counter"
+      'CounterType
+      (M.HashMap T.Text T.Text)
+  ExampleHistogram ::
+    ExampleMetrics
+      "my.histogram"
+      "Example histogram"
+      'HistogramType
+      (M.HashMap T.Text T.Text)

--- a/test/Store.hs
+++ b/test/Store.hs
@@ -11,7 +11,7 @@ import qualified Data.HashMap.Strict as HM
 import Test.Hspec
 import Test.HUnit (assertEqual)
 
-import qualified System.Metrics.Prometheus.Internal.Map2 as M2
+import qualified System.Metrics.Prometheus.Internal.Sample as Sample
 import System.Metrics.Prometheus.Internal.Store
 
 tests :: Spec
@@ -33,15 +33,15 @@ smokeTest = do
 
   let counterIdentifier = Identifier "ccounter" mempty
       gaugeIdentifier = Identifier "cgauge" mempty
-  !_ <- createCounter counterIdentifier store
-  !_ <- createGauge gaugeIdentifier store
+  !_ <- createCounter counterIdentifier "" store
+  !_ <- createGauge gaugeIdentifier "" store
 
   deregistrationHandle <- register store $ mconcat
-    [ registerCounter (Identifier "rcounter" mempty) (pure 0)
-    , registerGauge (Identifier "rgauge" mempty) (pure 0)
-    , flip registerGroup (pure ()) $ M2.fromList
-        [ ("group", HM.singleton "gcounter" mempty, const (Counter 0))
-        , ("group", HM.singleton "ggauge" mempty, const (Gauge 0))
+    [ registerCounter (Identifier "rcounter" mempty) "" (pure 0)
+    , registerGauge (Identifier "rgauge" mempty) "" (pure 0)
+    , flip registerGroup (pure ()) $ Sample.fromList
+        [ ("group", HM.singleton "gcounter" mempty, "", const (Counter 0))
+        , ("group", HM.singleton "ggauge" mempty, "", const (Gauge 0))
         ]
     ]
 

--- a/test/Store.hs
+++ b/test/Store.hs
@@ -8,10 +8,10 @@ module Store
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
 import qualified Data.HashMap.Strict as HM
-import qualified Data.Map.Strict as M
 import Test.Hspec
 import Test.HUnit (assertEqual)
 
+import qualified System.Metrics.Prometheus.Internal.Map2 as M2
 import System.Metrics.Prometheus.Internal.Store
 
 tests :: Spec
@@ -39,9 +39,9 @@ smokeTest = do
   deregistrationHandle <- register store $ mconcat
     [ registerCounter (Identifier "rcounter" mempty) (pure 0)
     , registerGauge (Identifier "rgauge" mempty) (pure 0)
-    , flip registerGroup (pure ()) $ M.fromList
-        [ (Identifier "group" (HM.singleton "gcounter" mempty), const (Counter 0))
-        , (Identifier "group" (HM.singleton "ggauge" mempty), const (Gauge 0))
+    , flip registerGroup (pure ()) $ M2.fromList
+        [ ("group", HM.singleton "gcounter" mempty, const (Counter 0))
+        , ("group", HM.singleton "ggauge" mempty, const (Gauge 0))
         ]
     ]
 


### PR DESCRIPTION
This PR adds support for annotating metrics with help text documentation.

For example, this is how a metrics sample might look after this PR:

```diff
+# HELP _100gauge Example gauge
 # TYPE _100gauge gauge
 _100gauge 100.0
 
+# HELP my_counter Example counter
 # TYPE my_counter counter
 my_counter{label_name_2="label value 1",label_name_1="label value 1"} 10.0
 my_counter{label_name_2="label value 2",label_name_1="label value 2"} 11.0
 
+# HELP my_histogram Example histogram
 # TYPE my_histogram histogram
 my_histogram_bucket{le="1.0",label_name="label_value"} 1
 my_histogram_bucket{le="2.0",label_name="label_value"} 2
```