### PR TITLE
Validate metric names, label names, and help text at registration time

### DIFF
--- a/System/Metrics/Prometheus.hs
+++ b/System/Metrics/Prometheus.hs
@@ -63,7 +63,7 @@ module System.Metrics.Prometheus
     -- $registering
   , register
   , Registration
-  , ValidationError (..)
+  , Internal.ValidationError (..)
   , registerCounter
   , registerGauge
   , registerHistogram
@@ -106,7 +106,6 @@ import System.Metrics.Prometheus.Histogram (HistogramSample)
 import qualified System.Metrics.Prometheus.Histogram as Histogram
 import qualified System.Metrics.Prometheus.Internal.Sample as Sample
 import qualified System.Metrics.Prometheus.Internal.Store as Internal
-import System.Metrics.Prometheus.Validation (ValidationError (..))
 
 -- $overview
 -- Metrics are used to monitor program behavior and performance. All

--- a/System/Metrics/Prometheus.hs
+++ b/System/Metrics/Prometheus.hs
@@ -63,6 +63,7 @@ module System.Metrics.Prometheus
     -- $registering
   , register
   , Registration
+  , ValidationError (..)
   , registerCounter
   , registerGauge
   , registerHistogram
@@ -105,6 +106,7 @@ import System.Metrics.Prometheus.Histogram (HistogramSample)
 import qualified System.Metrics.Prometheus.Histogram as Histogram
 import qualified System.Metrics.Prometheus.Internal.Sample as Sample
 import qualified System.Metrics.Prometheus.Internal.Store as Internal
+import System.Metrics.Prometheus.Validation (ValidationError (..))
 
 -- $overview
 -- Metrics are used to monitor program behavior and performance. All
@@ -417,7 +419,9 @@ ofAll _ = Metric
 -- be deregistered if the handle is handle used.
 
 -- | Atomically register one or more metrics. Returns a handle for
--- atomically deregistering those metrics specifically.
+-- atomically deregistering those metrics specifically. Throws
+-- 'ValidationError' if the given registration contains any invalid
+-- metric or label names.
 register
   :: Store metrics -- ^ Metric store
   -> Registration metrics -- ^ Registration action
@@ -818,80 +822,80 @@ emptyGCDetails = Stats.GCDetails
 data GcMetrics :: Symbol -> Symbol -> MetricType -> Type -> Type where
   Gcs ::
     GcMetrics
-      "rts.gcs"
+      "rts_gcs"
       "Total number of GCs"
       'CounterType
       ()
   MajorGcs ::
     GcMetrics
-      "rts.major_gcs"
+      "rts_major_gcs"
       "Total number of major (oldest generation) GCs"
       'CounterType
       ()
   AllocatedBytes ::
     GcMetrics
-      "rts.allocated_bytes"
+      "rts_allocated_bytes"
       "Total bytes allocated"
       'CounterType
       ()
   MaxLiveBytes ::
     GcMetrics
-      "rts.max_live_bytes"
+      "rts_max_live_bytes"
       "Maximum live data (including large objects + compact regions) in the heap. Updated after a major GC."
       'GaugeType
       ()
   MaxLargeObjectsBytes ::
     GcMetrics
-      "rts.max_large_objects_bytes"
+      "rts_max_large_objects_bytes"
       "Maximum live data in large objects"
       'GaugeType
       ()
   MaxCompactBytes ::
     GcMetrics
-      "rts.max_compact_bytes"
+      "rts_max_compact_bytes"
       "Maximum live data in compact regions"
       'GaugeType
       ()
   MaxSlopBytes ::
     GcMetrics
-      "rts.max_slop_bytes"
+      "rts_max_slop_bytes"
       "Maximum slop"
       'GaugeType
       ()
   MaxMemInUseBytes ::
     GcMetrics
-      "rts.max_mem_in_use_bytes"
+      "rts_max_mem_in_use_bytes"
       "Maximum memory in use by the RTS"
       'GaugeType
       ()
   CumulativeLiveBytes ::
     GcMetrics
-      "rts.cumulative_live_bytes"
+      "rts_cumulative_live_bytes"
       "Sum of live bytes across all major GCs. Divided by major_gcs gives the average live data over the lifetime of the program."
       'CounterType
       ()
   CopiedBytes ::
     GcMetrics
-      "rts.copied_bytes"
+      "rts_copied_bytes"
       "Sum of copied_bytes across all GCs"
       'CounterType
       ()
   ParCopiedBytes ::
     GcMetrics
-      "rts.par_copied_bytes"
+      "rts_par_copied_bytes"
       "Sum of copied_bytes across all parallel GCs"
       'GaugeType
       ()
   CumulativeParMaxCopiedBytes ::
     GcMetrics
-      "rts.cumulative_par_max_copied_bytes"
+      "rts_cumulative_par_max_copied_bytes"
       "Sum of par_max_copied_bytes across all parallel GCs. Deprecated."
       'GaugeType
       ()
 #if MIN_VERSION_base(4,11,0)
   CumulativeParBalancedCopiedBytes ::
     GcMetrics
-      "rts.cumulative_par_balanced_copied_bytes"
+      "rts_cumulative_par_balanced_copied_bytes"
       "Sum of par_balanced_copied bytes across all parallel GCs"
       'GaugeType
       ()
@@ -899,50 +903,50 @@ data GcMetrics :: Symbol -> Symbol -> MetricType -> Type -> Type where
 #if MIN_VERSION_base(4,12,0)
   InitCpuNs ::
     GcMetrics
-      "rts.init_cpu_ns"
+      "rts_init_cpu_ns"
       "Total CPU time used by the init phase @since 4.12.0.0"
       'CounterType
       ()
   InitElapsedNs ::
     GcMetrics
-      "rts.init_elapsed_ns"
+      "rts_init_elapsed_ns"
       "Total elapsed time used by the init phase @since 4.12.0.0"
       'CounterType
       ()
 #endif
   MutatorCpuNs ::
     GcMetrics
-      "rts.mutator_cpu_ns"
+      "rts_mutator_cpu_ns"
       "Total CPU time used by the mutator"
       'CounterType
       ()
   MutatorElapsedNs ::
     GcMetrics
-      "rts.mutator_elapsed_ns"
+      "rts_mutator_elapsed_ns"
       "Total elapsed time used by the mutator"
       'CounterType
       ()
   GcCpuNs ::
     GcMetrics
-      "rts.gc_cpu_ns"
+      "rts_gc_cpu_ns"
       "Total CPU time used by the GC"
       'CounterType
       ()
   GcElapsedNs ::
     GcMetrics
-      "rts.gc_elapsed_ns"
+      "rts_gc_elapsed_ns"
       "Total elapsed time used by the GC"
       'CounterType
       ()
   CpuNs ::
     GcMetrics
-      "rts.cpu_ns"
+      "rts_cpu_ns"
       "Total CPU time (at the previous GC)"
       'CounterType
       ()
   ElapsedNs ::
     GcMetrics
-      "rts.elapsed_ns"
+      "rts_elapsed_ns"
       "Total elapsed time (at the previous GC)"
       'CounterType
       ()
@@ -988,87 +992,87 @@ data GcMetrics :: Symbol -> Symbol -> MetricType -> Type -> Type where
   -- GCDetails
   GcDetailsGen ::
     GcMetrics
-      "rts.gc.gen"
+      "rts_gc_gen"
       "The generation number of this GC"
       'GaugeType
       ()
   GcDetailsThreads ::
     GcMetrics
-      "rts.gc.threads"
+      "rts_gc_threads"
       "Number of threads used in this GC"
       'GaugeType
       ()
   GcDetailsAllocatedBytes ::
     GcMetrics
-      "rts.gc.allocated_bytes"
+      "rts_gc_allocated_bytes"
       "Number of bytes allocated since the previous GC"
       'GaugeType
       ()
   GcDetailsLiveBytes ::
     GcMetrics
-      "rts.gc.live_bytes"
+      "rts_gc_live_bytes"
       "Total amount of live data in the heap (incliudes large + compact data). Updated after every GC. Data in uncollected generations (in minor GCs) are considered live."
       'GaugeType
       ()
   GcDetailsLargeObjectsBytes ::
     GcMetrics
-      "rts.gc.large_objects_bytes"
+      "rts_gc_large_objects_bytes"
       "Total amount of live data in large objects"
       'GaugeType
       ()
   GcDetailsCompactBytes ::
     GcMetrics
-      "rts.gc.compact_bytes"
+      "rts_gc_compact_bytes"
       "Total amount of live data in compact regions"
       'GaugeType
       ()
   GcDetailsSlopBytes ::
     GcMetrics
-      "rts.gc.slop_bytes"
+      "rts_gc_slop_bytes"
       "Total amount of slop (wasted memory)"
       'GaugeType
       ()
   GcDetailsMemInUseBytes ::
     GcMetrics
-      "rts.gc.mem_in_use_bytes"
+      "rts_gc_mem_in_use_bytes"
       "Total amount of memory in use by the RTS"
       'GaugeType
       ()
   GcDetailsCopiedBytes ::
     GcMetrics
-      "rts.gc.copied_bytes"
+      "rts_gc_copied_bytes"
       "Total amount of data copied during this GC"
       'GaugeType
       ()
   GcDetailsParMaxCopiedBytes ::
     GcMetrics
-      "rts.gc.par_max_copied_bytes"
+      "rts_gc_par_max_copied_bytes"
       "In parallel GC, the max amount of data copied by any one thread. Deprecated."
       'GaugeType
       ()
 #if MIN_VERSION_base(4,11,0)
   GcDetailsParBalancedCopiedBytes ::
     GcMetrics
-      "rts.gc.par_balanced_copied_bytes"
+      "rts_gc_par_balanced_copied_bytes"
       "In parallel GC, the amount of balanced data copied by all threads"
       'GaugeType
       ()
 #endif
   GcDetailsSyncElapsedNs ::
     GcMetrics
-      "rts.gc.sync_elapsed_ns"
+      "rts_gc_sync_elapsed_ns"
       "The time elapsed during synchronisation before GC"
       'GaugeType
       ()
   GcDetailsCpuNs ::
     GcMetrics
-      "rts.gc.cpu_ns"
+      "rts_gc_cpu_ns"
       "The CPU time used during GC itself"
       'GaugeType
       ()
   GcDetailsElapsedNs ::
     GcMetrics
-      "rts.gc.elapsed_ns"
+      "rts_gc_elapsed_ns"
       "The time elapsed during GC itself"
       'GaugeType
       ()

--- a/System/Metrics/Prometheus/Export.hs
+++ b/System/Metrics/Prometheus/Export.hs
@@ -157,7 +157,7 @@ sampleToPrometheus =
     . map exportGroupedMetric
     . mapMaybe
         ( makeGroupedMetric
-        . second (second (M.toAscList))
+        . second (second M.toAscList)
         )
     . M.toAscList
 

--- a/System/Metrics/Prometheus/Validation.hs
+++ b/System/Metrics/Prometheus/Validation.hs
@@ -47,16 +47,16 @@ isValidHelpText =
   checkResult . T.foldl' f initialCheckState
   where
     f :: CheckState -> Char -> CheckState
-    f CheckState{haveFoundError, isLastCharBackslash} char =
+    f CheckState{haveFoundError, isPrevCharBackslash} char =
       case char of
         '\n' -> CheckState True NotBackslash
         '\\' ->
-          if isLastCharBackslash == Backslash
+          if isPrevCharBackslash == Backslash
             then CheckState haveFoundError NotBackslash
             else CheckState haveFoundError Backslash
         'n' -> CheckState haveFoundError NotBackslash
         _ -> CheckState
-              (isLastCharBackslash == Backslash || haveFoundError)
+              (isPrevCharBackslash == Backslash || haveFoundError)
               NotBackslash
 
 -- | Test whether a string is a valid Prometheus label value.
@@ -72,26 +72,26 @@ isValidLabelValue =
   checkResult . T.foldl' f initialCheckState
   where
     f :: CheckState -> Char -> CheckState
-    f CheckState{haveFoundError, isLastCharBackslash} char =
+    f CheckState{haveFoundError, isPrevCharBackslash} char =
       case char of
         '\n' -> CheckState True NotBackslash
         '\\' ->
-          if isLastCharBackslash == Backslash
+          if isPrevCharBackslash == Backslash
             then CheckState haveFoundError NotBackslash
             else CheckState haveFoundError Backslash
         'n' -> CheckState haveFoundError NotBackslash
         '\"' ->
           -- Extra case relative to `isValidHelpText`
-          if isLastCharBackslash == Backslash
+          if isPrevCharBackslash == Backslash
             then CheckState haveFoundError NotBackslash
             else CheckState True NotBackslash
         _ -> CheckState
-              (isLastCharBackslash == Backslash || haveFoundError)
+              (isPrevCharBackslash == Backslash || haveFoundError)
               NotBackslash
 
 data CheckState = CheckState
   { haveFoundError :: !Bool
-  , isLastCharBackslash :: !IsBackslash
+  , isPrevCharBackslash :: !IsBackslash
   }
 
 data IsBackslash = Backslash | NotBackslash
@@ -100,9 +100,9 @@ data IsBackslash = Backslash | NotBackslash
 initialCheckState :: CheckState
 initialCheckState = CheckState
   { haveFoundError = False
-  , isLastCharBackslash = NotBackslash
+  , isPrevCharBackslash = NotBackslash
   }
 
 checkResult :: CheckState -> Bool
 checkResult st =
-  not (haveFoundError st) && isLastCharBackslash st == NotBackslash
+  not (haveFoundError st) && isPrevCharBackslash st == NotBackslash

--- a/System/Metrics/Prometheus/Validation.hs
+++ b/System/Metrics/Prometheus/Validation.hs
@@ -1,0 +1,40 @@
+module System.Metrics.Prometheus.Validation
+  ( ValidationError (..)
+  , isValidName
+  ) where
+
+import Control.Exception
+import Data.Char (isDigit)
+import qualified Data.Text as T
+
+data ValidationError
+  = InvalidMetricName T.Text
+  | InvalidLabelName T.Text
+
+instance Exception ValidationError
+
+instance Show ValidationError where
+  show (InvalidMetricName invalidName) =
+    "Invalid Prometheus metric name: " ++ T.unpack invalidName
+  show (InvalidLabelName invalidName) =
+    "Invalid Prometheus label name: " ++ T.unpack invalidName
+
+-- | Test whether a string is a valid Prometheus name by checking that it
+-- matches the regex @[a-zA-Z_][a-zA-Z0-9_]*@.
+-- See
+-- <https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels>
+-- for more details.
+--
+isValidName :: T.Text -> Bool
+isValidName name =
+    case T.uncons name of
+        Nothing -> False
+        Just (headChar, _tail) ->
+            isInitialNameChar headChar && T.all isNameChar name
+
+isNameChar :: Char -> Bool
+isNameChar c = isInitialNameChar c || isDigit c
+
+isInitialNameChar :: Char -> Bool
+isInitialNameChar c =
+  'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_'

--- a/System/Metrics/Prometheus/Validation.hs
+++ b/System/Metrics/Prometheus/Validation.hs
@@ -1,15 +1,22 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 module System.Metrics.Prometheus.Validation
   ( ValidationError (..)
   , isValidName
+  , isValidHelpText
+  , isValidLabelValue
   ) where
 
 import Control.Exception
 import Data.Char (isDigit)
 import qualified Data.Text as T
 
+--------------------------------------------------------------------------------
+
 data ValidationError
   = InvalidMetricName T.Text
   | InvalidLabelName T.Text
+  | InvalidHelpText T.Text
 
 instance Exception ValidationError
 
@@ -18,6 +25,10 @@ instance Show ValidationError where
     "Invalid Prometheus metric name: " ++ T.unpack invalidName
   show (InvalidLabelName invalidName) =
     "Invalid Prometheus label name: " ++ T.unpack invalidName
+  show (InvalidHelpText invalidHelpText) =
+    "Invalid Prometheus help text: " ++ T.unpack invalidHelpText
+
+--------------------------------------------------------------------------------
 
 -- | Test whether a string is a valid Prometheus name by checking that it
 -- matches the regex @[a-zA-Z_][a-zA-Z0-9_]*@.
@@ -38,3 +49,79 @@ isNameChar c = isInitialNameChar c || isDigit c
 isInitialNameChar :: Char -> Bool
 isInitialNameChar c =
   'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_'
+
+--------------------------------------------------------------------------------
+
+-- | Test whether a string is valid Prometheus help text.
+--
+-- According to <https://prometheus.io/docs/instrumenting/exposition_formats/>,
+-- help text may contain any sequence of UTF-8 characters, but the backslash
+-- (@\\@) and line feed (@\\n@) characters have to be escaped as @\\\\@ and
+-- @\\n@,
+-- respectively.
+isValidHelpText :: T.Text -> Bool
+isValidHelpText =
+  -- Using a strict left fold because we almost always expect a valid string,
+  -- for which verification requires traversing the entire string.
+  checkResult . T.foldl' f initialCheckState
+  where
+    f :: CheckState -> Char -> CheckState
+    f CheckState{haveFoundError, isLastCharBackslash} char =
+      case char of
+        '\n' -> CheckState True NotBackslash
+        '\\' ->
+          if isLastCharBackslash == Backslash
+            then CheckState haveFoundError NotBackslash
+            else CheckState haveFoundError Backslash
+        'n' -> CheckState haveFoundError NotBackslash
+        _ -> CheckState
+              (isLastCharBackslash == Backslash || haveFoundError)
+              NotBackslash
+
+-- | Test whether a string is a valid Prometheus label value.
+--
+-- According to <https://prometheus.io/docs/instrumenting/exposition_formats/>,
+-- label values can be any sequence of UTF-8 characters, but the backslash
+-- (@\\@), double-quote (@"@), and line feed (@\\n@) characters have to be
+-- escaped as @\\\\@, @\\"@, and @\\n@, respectively.
+isValidLabelValue :: T.Text -> Bool
+isValidLabelValue =
+  -- Using a strict left fold because we almost always expect a valid string,
+  -- for which verification requires traversing the entire string.
+  checkResult . T.foldl' f initialCheckState
+  where
+    f :: CheckState -> Char -> CheckState
+    f CheckState{haveFoundError, isLastCharBackslash} char =
+      case char of
+        '\n' -> CheckState True NotBackslash
+        '\\' ->
+          if isLastCharBackslash == Backslash
+            then CheckState haveFoundError NotBackslash
+            else CheckState haveFoundError Backslash
+        'n' -> CheckState haveFoundError NotBackslash
+        '\"' ->
+          -- Extra case relative to `isValidHelpText`
+          if isLastCharBackslash == Backslash
+            then CheckState haveFoundError NotBackslash
+            else CheckState True NotBackslash
+        _ -> CheckState
+              (isLastCharBackslash == Backslash || haveFoundError)
+              NotBackslash
+
+data CheckState = CheckState
+  { haveFoundError :: !Bool
+  , isLastCharBackslash :: !IsBackslash
+  }
+
+data IsBackslash = Backslash | NotBackslash
+  deriving (Eq)
+
+initialCheckState :: CheckState
+initialCheckState = CheckState
+  { haveFoundError = False
+  , isLastCharBackslash = NotBackslash
+  }
+
+checkResult :: CheckState -> Bool
+checkResult st =
+  not (haveFoundError st) && isLastCharBackslash st == NotBackslash

--- a/System/Metrics/Prometheus/Validation.hs
+++ b/System/Metrics/Prometheus/Validation.hs
@@ -1,32 +1,13 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module System.Metrics.Prometheus.Validation
-  ( ValidationError (..)
-  , isValidName
+  ( isValidName
   , isValidHelpText
   , isValidLabelValue
   ) where
 
-import Control.Exception
 import Data.Char (isDigit)
 import qualified Data.Text as T
-
---------------------------------------------------------------------------------
-
-data ValidationError
-  = InvalidMetricName T.Text
-  | InvalidLabelName T.Text
-  | InvalidHelpText T.Text
-
-instance Exception ValidationError
-
-instance Show ValidationError where
-  show (InvalidMetricName invalidName) =
-    "Invalid Prometheus metric name: " ++ T.unpack invalidName
-  show (InvalidLabelName invalidName) =
-    "Invalid Prometheus label name: " ++ T.unpack invalidName
-  show (InvalidHelpText invalidHelpText) =
-    "Invalid Prometheus help text: " ++ T.unpack invalidHelpText
 
 --------------------------------------------------------------------------------
 

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -88,8 +88,8 @@ data AppMetrics1
   -> Type -- ^ Label set structure
   -> Type
   where
-  Requests :: AppMetrics1 "my_app.requests" "" 'CounterType ()
-  Connections :: AppMetrics1 "my_app.connections" "" 'GaugeType ()
+  Requests :: AppMetrics1 "app_requests" "" 'CounterType ()
+  Connections :: AppMetrics1 "app_connections" "" 'GaugeType ()
 ```
 
 The `AppMetrics1` GADT has two constructors, `Requests` and
@@ -98,7 +98,7 @@ of each constructor determine the name, type, and "label structure" of
 their corresponding metric. For example, the `Requests` constructor
 specifies a metric with:
 
-* name "my_app.requests", and
+* name "app_requests", and
 * type counter, and
 * labels disabled.
 
@@ -136,8 +136,8 @@ app1 = do
 
   -- Verify the sample, just for this tutorial.
   let expectedSample = M.fromList
-        [ ("my_app.requests", ("", M.singleton HM.empty (Counter 1)))
-        , ("my_app.connections", ("", M.singleton HM.empty (Gauge 99)))
+        [ ("app_requests", ("", M.singleton HM.empty (Counter 1)))
+        , ("app_connections", ("", M.singleton HM.empty (Gauge 99)))
         ]
   assert (sample == expectedSample) $ pure ()
 ```
@@ -329,8 +329,8 @@ app3 = do
 
   sample1 <- sampleAll store
   let expectedSample1 = M.fromList
-        [ ("my_app.requests", ("", M.singleton HM.empty (Counter 1)))
-        , ("my_app.connections", ("", M.singleton HM.empty (Gauge 99)))
+        [ ("app_requests", ("", M.singleton HM.empty (Counter 1)))
+        , ("app_connections", ("", M.singleton HM.empty (Gauge 99)))
         ]
   assert (sample1 == expectedSample1) $ pure ()
 
@@ -342,8 +342,8 @@ app3 = do
 
   sample2 <- sampleAll store
   let expectedSample2 = M.fromList
-        [ ("my_app.requests", ("", M.singleton HM.empty (Counter 1)))
-        , ("my_app.connections", ("", M.singleton HM.empty (Gauge 5)))
+        [ ("app_requests", ("", M.singleton HM.empty (Counter 1)))
+        , ("app_connections", ("", M.singleton HM.empty (Gauge 5)))
         ]
   assert (sample2 == expectedSample2) $ pure ()
 
@@ -352,7 +352,7 @@ app3 = do
 
   sample3 <- sampleAll store
   let expectedSample3 =
-        M.singleton "my_app.connections" $
+        M.singleton "app_connections" $
           ("", M.singleton HM.empty (Gauge 5))
   assert (sample3 == expectedSample3) $ pure ()
 ```
@@ -438,8 +438,8 @@ example program that does this:
 ```haskell
 -- (1)
 data GcMetrics' :: Symbol -> Symbol -> MetricType -> Type -> Type where
-  Gcs' :: GcMetrics' "rts.gcs" "" 'CounterType ()
-  MaxLiveBytes' :: GcMetrics' "rts.max_live_bytes" "" 'GaugeType ()
+  Gcs' :: GcMetrics' "rts_gcs" "" 'CounterType ()
+  MaxLiveBytes' :: GcMetrics' "rts_max_live_bytes" "" 'GaugeType ()
 
 app5 :: IO ()
 app5 = do

--- a/ekg-prometheus.cabal
+++ b/ekg-prometheus.cabal
@@ -44,6 +44,7 @@ library
     System.Metrics.Prometheus.Internal.Sample
     System.Metrics.Prometheus.Internal.State
     System.Metrics.Prometheus.Internal.Store
+    System.Metrics.Prometheus.Validation
 
   other-modules:
     Data.Array

--- a/ekg-prometheus.cabal
+++ b/ekg-prometheus.cabal
@@ -85,6 +85,7 @@ test-suite ekg-prometheus-test
     Export
     State
     Store
+    Validation
   build-depends:
     base,
     ekg-prometheus,

--- a/ekg-prometheus.cabal
+++ b/ekg-prometheus.cabal
@@ -94,6 +94,7 @@ test-suite ekg-prometheus-test
     bytestring,
     containers,
     hspec ^>= 2.8.2,
+    hspec-expectations ^>= 0.8.2,
     hspec-smallcheck ^>= 0.5.2,
     HUnit ^>= 1.6.2.0,
     QuickCheck ^>= 2.14.2,

--- a/test/Export.hs
+++ b/test/Export.hs
@@ -41,14 +41,14 @@ tests =
   counter1 <-
     createCounter
       ExampleCounter
-      (M.fromList [("label.name.1", "label value 1"), ("label.name.2", "label value 1")])
+      (M.fromList [("label_name_1", "label value 1"), ("label_name_2", "label value 1")])
       store
   Counter.add counter1 10
 
   counter2 <-
     createCounter
       ExampleCounter
-      (M.fromList [("label.name.1", "label value 2"), ("label.name.2", "label value 2")])
+      (M.fromList [("label_name_1", "label value 2"), ("label_name_2", "label value 2")])
       store
   Counter.add counter2 11
 
@@ -65,24 +65,24 @@ tests =
     BB.toLazyByteString . sampleToPrometheus <$> sampleAll store
 
   shouldBe prometheusSample
-    "# HELP _100gauge Example gauge\n# TYPE _100gauge gauge\n_100gauge 100.0\n\n# HELP my_counter Example counter\n# TYPE my_counter counter\nmy_counter{label_name_2=\"label value 1\",label_name_1=\"label value 1\"} 10.0\nmy_counter{label_name_2=\"label value 2\",label_name_1=\"label value 2\"} 11.0\n\n# HELP my_histogram Example histogram\n# TYPE my_histogram histogram\nmy_histogram_bucket{le=\"1.0\",label_name=\"label_value\"} 1\nmy_histogram_bucket{le=\"2.0\",label_name=\"label_value\"} 2\nmy_histogram_bucket{le=\"3.0\",label_name=\"label_value\"} 3\nmy_histogram_bucket{le=\"+Inf\",label_name=\"label_value\"} 4\nmy_histogram_sum{label_name=\"label_value\"} 10.0\nmy_histogram_count{label_name=\"label_value\"} 4\n"
+    "# HELP my_counter Example counter\n# TYPE my_counter counter\nmy_counter{label_name_2=\"label value 1\",label_name_1=\"label value 1\"} 10.0\nmy_counter{label_name_2=\"label value 2\",label_name_1=\"label value 2\"} 11.0\n\n# HELP my_gauge Example gauge\n# TYPE my_gauge gauge\nmy_gauge 100.0\n\n# HELP my_histogram Example histogram\n# TYPE my_histogram histogram\nmy_histogram_bucket{le=\"1.0\",label_name=\"label_value\"} 1\nmy_histogram_bucket{le=\"2.0\",label_name=\"label_value\"} 2\nmy_histogram_bucket{le=\"3.0\",label_name=\"label_value\"} 3\nmy_histogram_bucket{le=\"+Inf\",label_name=\"label_value\"} 4\nmy_histogram_sum{label_name=\"label_value\"} 10.0\nmy_histogram_count{label_name=\"label_value\"} 4\n"
 
 data ExampleMetrics :: Symbol -> Symbol -> MetricType -> Type -> Type where
   ExampleGauge ::
     ExampleMetrics
-      "100gauge"
+      "my_gauge"
       "Example gauge"
       'GaugeType
       ()
   ExampleCounter ::
     ExampleMetrics
-      "my.counter"
+      "my_counter"
       "Example counter"
       'CounterType
       (M.HashMap T.Text T.Text)
   ExampleHistogram ::
     ExampleMetrics
-      "my.histogram"
+      "my_histogram"
       "Example histogram"
       'HistogramType
       (M.HashMap T.Text T.Text)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -6,6 +6,7 @@ import qualified Counter
 import qualified Export
 import qualified State
 import qualified Store
+import qualified Validation
 
 main :: IO ()
 main = hspec $ do
@@ -13,3 +14,4 @@ main = hspec $ do
   Store.tests
   Counter.tests
   Export.tests
+  Validation.tests

--- a/test/Validation.hs
+++ b/test/Validation.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Validation
+  ( tests
+  ) where
+
+import Test.Hspec
+  ( Spec,
+    describe,
+    it,
+    shouldBe,
+  )
+
+import System.Metrics.Prometheus.Validation
+  ( isValidHelpText,
+    isValidLabelValue
+  )
+
+-- | Basic tests of the valdiation functions.
+tests :: Spec
+tests =
+  describe "Validation functions" $ do
+    describe "`isValidHelpText`" $ do
+      it "accepts empty strings" $
+        isValidHelpText "" `shouldBe` True
+      it "accepts escaped backslashes and newlines" $
+        isValidHelpText "\\\\,\\n" `shouldBe` True
+      it "rejects unescaped backslashes" $ do
+        isValidHelpText "\\" `shouldBe` False
+        isValidHelpText "\\t" `shouldBe` False
+      it "rejects unescaped newlines" $
+        isValidHelpText "\n" `shouldBe` False
+    describe "`isValidLabelValue`" $ do
+      it "accepts empty strings" $
+        isValidLabelValue "" `shouldBe` True
+      it "accepts escaped backslashes, newlines, and double-quotes" $
+        isValidLabelValue "\\\\,\\n,\\\"" `shouldBe` True
+      it "rejects unescaped backslashes" $ do
+        isValidLabelValue "\\" `shouldBe` False
+        isValidLabelValue "\\t" `shouldBe` False
+      it "rejects unescaped newlines" $
+        isValidLabelValue "\n" `shouldBe` False
+      it "rejects unescaped double-quotes" $
+        isValidLabelValue "\"" `shouldBe` False


### PR DESCRIPTION
This PR adds validation of metric names, label names, and help text at metric registration time, throwing a validation error if any are invalid. This PR also removes sanitization of metric and label names at export time.

Closes #5.

#### Changes

- Add validation of metric names, label names, and help text at metric registration time (`System/Metrics/Prometheus/Internal/Store.hs`)
  - Extends the type of `Registration` with `Either` to encode validation failures
- Remove sanitization of metric and label names at export time (`System/Metrics/Prometheus/Export.hs`)
- Renaming metrics and labels to valid Prometheus names (e.g. removal of the `'.'` character)
  - In the `GcMetrics` specification (`System/Metrics/Prometheus.hs`)
  - In the tests for exporting metrics (`test/Export.hs`)
  - In various metrics specifications in the tutorial (`Tutorial.md`)
- Add a function for validation of label values, which is currently unused.

#### Design

- Throwing exceptions for invalid metric and label names should not be burdensome if one follows the recommended convention that metric and label names be determined statically (that is, that they should not depend on runtime information), in which case such exceptions should be detected readily during testing.
- On the other hand, label values are often generated dynamically, so some invalid values may only be detected during runtime in production. Then, I hesitate to throw exceptions for invalid label values in case a user would prefer to have broken metrics rather than downtime.
  - We can add more mechanisms for safe label values later.