### PR TITLE
Check for collisions of metric identifiers on registration

### DIFF
--- a/System/Metrics/Prometheus/GroupExample.hs
+++ b/System/Metrics/Prometheus/GroupExample.hs
@@ -28,5 +28,4 @@ main = do
         SamplingGroup
           :> (RTSGcs, (), fromIntegral . gcs)
           :> (RTSMaxLiveBytes, (), fromIntegral . max_live_bytes)
-  _ <- register store $ registerGroup samplingGroup getRTSStats
-  pure ()
+  registerPermanently store $ registerGroup samplingGroup getRTSStats

--- a/System/Metrics/Prometheus/Internal/Store.hs
+++ b/System/Metrics/Prometheus/Internal/Store.hs
@@ -3,7 +3,7 @@
 -- This module defines the metrics store and all of its operations using
 -- the state type defined in "System.Metrics.Prometheus.Internal.State". The
 -- interface presented in this module is then restricted in
--- "System.Metrics.Prometheus.Static" to produce the final interface.
+-- "System.Metrics.Prometheus" to produce the final interface.
 --
 -- = Warning
 --
@@ -17,13 +17,23 @@
 -- * We wrap the internal `State` in an `IORef`, making it suitable as a
 --   global store.
 --
--- * We wrap operations on the `State` and allow them to be composed,
---   then run such compositions atomically using `atomicModifyIORef'`.
---   This allows for atomic operations on the `Store`.
+-- * We wrap operations on the `State` (as `Registration`s) and allow
+--   them to be composed, then run such compositions atomically using
+--   `atomicModifyIORef'`. This allows for atomic operations on the
+--   `Store`.
 --
--- * We bind the `Handle`s of "System.Metrics.Prometheus.Internal.State" to
---   specific `IORef`s in `deregisterHandles`, preventing the confusion of
---   handles from different `Store`s.
+-- * We bind the deregistration `Handle`s of
+--   "System.Metrics.Prometheus.Internal.State" to specific `IORef`s in
+--   `deregisterHandles`, preventing the confusion of handles from
+--   different `Store`s.
+--
+-- * We validate metric names, metric help text, and label names before
+--   they are registered. (Label values are currently unchecked.)
+--
+-- * We allow metrics to be registered as either "mutable" or
+--   "immutable". "Immutable" metrics are intended to be permanent
+--   fixtures that cannot be touched once registered, while "mutable"
+--   can be removed or replaced at will.
 
 module System.Metrics.Prometheus.Internal.Store
     (
@@ -41,7 +51,10 @@ module System.Metrics.Prometheus.Internal.Store
       -- * Registering metrics
       -- $registering
     , Registration
-    , register
+    , RegistrationError (..)
+    , registerPermanently
+    , registerRemovably
+    , registerRemovablyCatch
     , registerCounter
     , registerGauge
     , registerHistogram
@@ -65,7 +78,9 @@ module System.Metrics.Prometheus.Internal.Store
 
 import Control.Exception (Exception, throwIO)
 import Control.Monad (unless)
-import Data.Foldable (for_)
+import Data.Bifunctor (first)
+import Data.Foldable (for_, traverse_)
+import Data.Functor (void)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import qualified Data.HashMap.Strict as HM
 import Data.List (foldl')
@@ -104,38 +119,111 @@ newStore = Store <$> newIORef initialState
 -- | An action that registers one or more metrics to a metric store.
 newtype Registration =
   Registration
-    (State -> Either ValidationError (State, [Handle] -> [Handle]))
+    ( Mutability
+      -> State
+      -> Either RegistrationError (State, [Handle] -> [Handle])
+    )
 
 instance Semigroup Registration where
-  Registration f <> Registration g = Registration $ \state0 -> do
-    (state1, h1) <- f state0
-    (state2, h2) <- g state1
-    pure (state2, h2 . h1)
+  Registration f <> Registration g =
+    Registration $ \mutability state0 -> do
+      (state1, h1) <- f mutability state0
+      (state2, h2) <- g mutability state1
+      pure (state2, h2 . h1)
 
 instance Monoid Registration where
-  mempty = Registration $ \state -> Right (state, id)
+  mempty = Registration $ \_mutability state -> Right (state, id)
 
--- | Atomically apply a registration action to a metrics store. Returns
--- an action to (atomically) deregister the newly registered metrics.
--- Throws 'ValidationError' if the given registration contains any
--- invalid metric or label names.
-register
+-- | Errors that can occur during the registration of metrics
+data RegistrationError
+  = ValidationError ValidationError
+  | MetricIdentifierAlreadyUsed Name Labels
+  deriving (Show)
+
+instance Exception RegistrationError
+
+-- | Atomically apply a registration action to a metrics store,
+-- registering the metrics as "permanent" metrics that cannot be removed
+-- or replaced. In case of collisions of metric identifiers (name and
+-- labels), throws an exception.
+--
+-- Throws a 'RegistrationError' exception if
+--
+-- * the registration attempts to register a metric with the name and
+--   labels of an existing metric in the store; or if
+--
+-- * the registration contains invalid metric names, label names, or
+--   help text.
+registerPermanently
   :: Store -- ^ Metric store
   -> Registration -- ^ Registration action
+  -> IO ()
+registerPermanently = fmap void . registerThrow Permanent
+
+-- | Atomically apply a registration action to a metrics store,
+-- registering the metrics as "removable" metrics that can later be
+-- removed or replaced. Returns an action to (atomically) deregister the
+-- newly registered metrics. In case of collisions of metric identifiers
+-- (name and labels), replaces existing metrics if they are removable,
+-- and throws an exception if they are permanent.
+
+-- Throws a 'RegistrationError' exception if
+--
+-- * the registration attempts to register a metric with the name and
+--   labels of an existing metric in the store, _unless_ the existing
+--   metric was registered as a removable metric via 'registerRemovably;
+--   or if
+--
+-- * the registration contains invalid metric names, label names, or
+--   help text.
+registerRemovably
+  :: Store -- ^ Metric store
+  -> Registration -- ^ Registration action
+  -> IO (IO ())
+registerRemovably = registerThrow Removable
+
+-- | Like 'registerRemovably', but returns 'RegistrationError's via
+-- 'Either' rather than throwing them.
+registerRemovablyCatch
+  :: Store -- ^ Metric store
+  -> Registration -- ^ Registration action
+  -> IO
+      ( Either
+          RegistrationError
+          (IO ()) -- ^ Deregistration action
+      )
+registerRemovablyCatch = registerCatch Removable
+
+registerThrow
+  :: Mutability -- ^ Whether the metrics should be registered as permament or removable
+  -> Store -- ^ Metric store
+  -> Registration -- ^ Registration action
   -> IO (IO ()) -- ^ Deregistration action
-register (Store stateRef) (Registration f) = do
-    result <- atomicModifyIORef' stateRef $ \state0 ->
-        case f state0 of
+registerThrow mutability store registration = do
+    result <- registerCatch mutability store registration
+    case result of
+        Left validationError -> throwIO validationError
+        Right deregisterAction -> pure deregisterAction
+
+registerCatch
+  :: Mutability -- ^ Whether the metrics should be registered as permament or removable
+  -> Store -- ^ Metric store
+  -> Registration -- ^ Registration action
+  -> IO
+      ( Either
+          RegistrationError
+          (IO ()) -- ^ Deregistration action
+      )
+registerCatch mutability (Store stateRef) (Registration f) = do
+    atomicModifyIORef' stateRef $ \state0 ->
+        case f mutability state0 of
             Left validationError ->
-                -- Preserve state on error
+                -- Preserve initial state on error
                 (state0, Left validationError)
             Right (state1, handles') ->
                 let deregisterAction =
                         deregisterHandles (handles' []) stateRef
                 in  (state1, Right deregisterAction)
-    case result of
-        Left validationError -> throwIO validationError
-        Right deregisterAction -> pure deregisterAction
 
 -- | Deregister the metrics referred to by the given handles.
 deregisterHandles
@@ -180,11 +268,12 @@ registerGeneric
   -> MetricSampler -- ^ Sampling action
   -> Registration -- ^ Registration action
 registerGeneric identifier help sample =
-  Registration $ \state0 -> do
-      validateIdentifier identifier
-      validateHelpText help
+  Registration $ \mutability state0 -> do
+      first ValidationError $ validateIdentifier identifier
+      first ValidationError $ validateHelpText help
+      checkIdentifierCollision mutability identifier state0
       let (state1, handle) =
-            Internal.register identifier help sample state0
+            Internal.register identifier help sample mutability state0
       pure (state1, (:) handle)
 
 registerGroup
@@ -192,10 +281,12 @@ registerGroup
         -- ^ Metric names and getter functions
     -> IO a -- ^ Action to sample the metric group
     -> Registration -- ^ Registration action
-registerGroup getters cb = Registration $ \state0 -> do
-    validateGroupGetters getters
-    let (state1, handles) = Internal.registerGroup getters cb state0
-    pure (state1, (++) handles)
+registerGroup getters cb =
+    Registration $ \mutability state0 -> do
+        validateGroupGetters state0 mutability getters
+        let (state1, handles) =
+                Internal.registerGroup getters cb mutability state0
+        pure (state1, (++) handles)
 
 ------------------------------------------------------------------------
 -- ** Validation
@@ -206,14 +297,20 @@ validateIdentifier identifier = do
     for_ (HM.keys (idLabels identifier)) validateLabelName
 
 validateGroupGetters
-    :: M.Map Name (Help, M.Map Labels (a -> Value))
-    -> Either ValidationError ()
-validateGroupGetters getters =
+    :: State
+    -> Mutability
+    -> M.Map Name (Help, M.Map Labels (a -> Value))
+    -> Either RegistrationError ()
+validateGroupGetters state mutability getters =
     for_ (M.toList getters) $ \(metricName, (help, labelSetMap)) -> do
-        validateMetricName metricName
-        validateHelpText help
-        for_ (M.keys labelSetMap) $ \labelSet ->
-            for_ (HM.keys labelSet) validateLabelName
+        first ValidationError $ validateMetricName metricName
+        first ValidationError $ validateHelpText help
+        for_ (M.keys labelSetMap) $ \labelSet -> do
+            traverse_
+                (first ValidationError . validateLabelName)
+                (HM.keys labelSet)
+            let identifier = Identifier metricName labelSet
+            checkIdentifierCollision mutability identifier state
 
 validateMetricName :: Text -> Either ValidationError ()
 validateMetricName labelName =
@@ -229,6 +326,36 @@ validateHelpText :: Text -> Either ValidationError ()
 validateHelpText help =
     unless (isValidHelpText help) $
         Left (InvalidHelpText help)
+
+checkIdentifierCollision ::
+    Mutability -> Identifier -> State -> Either RegistrationError ()
+checkIdentifierCollision mutability identifier state =
+    case Internal.lookupMutability identifier state of
+        Nothing -> Right ()
+        Just Permanent ->
+          Left $
+            MetricIdentifierAlreadyUsed
+              (idName identifier)
+              (idLabels identifier)
+        Just Removable ->
+            case mutability of
+                Removable ->
+                  Right ()
+                Permanent ->
+                  -- Rationale: Non-deterministic execution could result
+                  -- instead in this permanent metric being registered
+                  -- first and the removable metric being registered
+                  -- afterwards, triggering a previous case in which an
+                  -- error is thrown. To be consistent, we should also
+                  -- throw the same error.
+                  --
+                  -- Permanent metrics should be the only metric
+                  -- registered at their identifiers for the lifetime of
+                  -- the metrics store.
+                  Left $
+                    MetricIdentifierAlreadyUsed
+                      (idName identifier)
+                      (idLabels identifier)
 
 data ValidationError
   = InvalidMetricName Text
@@ -249,35 +376,40 @@ instance Show ValidationError where
 -- ** Convenience functions
 
 -- $convenience
--- These functions combined the creation of a mutable reference (e.g.
--- a `System.Metrics.Prometheus.Counter.Counter`) with registering that reference
--- in the store in one convenient function. The deregistration handles
--- are discarded.
+-- These functions combine the creation of a mutable reference (e.g. a
+-- `System.Metrics.Prometheus.Counter.Counter`) with registering that
+-- reference as a permanent metric.
 
--- | Create and register a zero-initialized counter.
+-- | Create and permanently register a zero-initialized counter.
+--
+-- Can throw 'RegistrationError' exceptions.
 createCounter :: Identifier -- ^ Counter identifier
               -> Help -- ^ Metric documentation
               -> Store      -- ^ Metric store
               -> IO Counter
 createCounter identifier help store = do
     counter <- Counter.new
-    _ <- register store $
-          registerCounter identifier help (Counter.read counter)
+    registerPermanently store $
+        registerCounter identifier help (Counter.read counter)
     return counter
 
--- | Create and register a zero-initialized gauge.
+-- | Create and permanently register a zero-initialized gauge.
+--
+-- Can throw 'RegistrationError' exceptions.
 createGauge :: Identifier -- ^ Gauge identifier
             -> Help -- ^ Metric documentation
             -> Store      -- ^ Metric store
             -> IO Gauge
 createGauge identifier help store = do
     gauge <- Gauge.new
-    _ <- register store $
-          registerGauge identifier help (Gauge.read gauge)
+    registerPermanently store $
+        registerGauge identifier help (Gauge.read gauge)
     return gauge
 
--- | Create and register an empty histogram. The buckets of the
--- histogram are fixed and defined by the given upper bounds.
+-- | Create and permanently register an empty histogram. The buckets of
+-- the histogram are fixed and defined by the given upper bounds.
+--
+-- Can throw 'RegistrationError' exceptions.
 createHistogram :: [Histogram.UpperBound] -- ^ Upper bounds of buckets
                 -> Identifier -- ^ Histogram identifier
                 -> Help -- ^ Metric documentation
@@ -285,8 +417,8 @@ createHistogram :: [Histogram.UpperBound] -- ^ Upper bounds of buckets
                 -> IO Histogram
 createHistogram upperBounds identifier help store = do
     histogram <- Histogram.new upperBounds
-    _ <- register store $
-          registerHistogram identifier help (Histogram.read histogram)
+    registerPermanently store $
+        registerHistogram identifier help (Histogram.read histogram)
     return histogram
 
 ------------------------------------------------------------------------

--- a/ekg-prometheus.cabal
+++ b/ekg-prometheus.cabal
@@ -14,8 +14,7 @@ maintainer:          Johan Tibell <johan.tibell@gmail.com>,
 category:            System
 build-type:          Simple
 extra-source-files:  CHANGES.md
-tested-with:         GHC == 8.10.7, GHC == 8.8.3, GHC == 8.6.5,
-                     GHC == 8.4.4,  GHC == 8.2.2
+tested-with:         GHC == 9.2.5, GHC == 8.10.7
 
 common common-all
   ghc-options:

--- a/test/Store.hs
+++ b/test/Store.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -10,11 +11,13 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
 import Control.Monad (void)
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Test.Hspec
 import Test.HUnit (assertEqual)
 
 import qualified System.Metrics.Prometheus.Internal.Sample as Sample
+import System.Metrics.Prometheus.Histogram (HistogramSample (..))
 import System.Metrics.Prometheus.Internal.Store
 
 tests :: Spec
@@ -22,6 +25,9 @@ tests =
   describe "The internal Store interface" $ do
     it "passes a smoke test" test_smokeTest
     it "throws exceptions on invalid input" test_validation
+    describe
+      "Permanent and removable metrics"
+      test_permanentAndRemovableMetrics
 
 -- | A test that simply runs functions from the interface to make sure they
 -- don't throw errors or never return, that is, that they don't evaluate to
@@ -42,40 +48,101 @@ smokeTest = do
   !_ <- createGauge gaugeIdentifier "" store
   !_ <- createHistogram [] histogramIdentifier "" store
 
-  deregistrationHandle <- register store $ mconcat
-    [ registerCounter (Identifier "rcounter" mempty) "" (pure 0)
-    , registerGauge (Identifier "rgauge" mempty) "" (pure 0)
-    , flip registerGroup (pure ()) $ Sample.fromList
-        [ ("group", HM.singleton "gcounter" mempty, "", const (Counter 0))
-        , ("group", HM.singleton "ggauge" mempty, "", const (Gauge 0))
-        ]
-    ]
+  let registration :: Text -> Registration
+      registration prefix =
+        mconcat
+          [ registerCounter (Identifier (prefix <> "counter") mempty) "" (pure 0)
+          , registerGauge (Identifier (prefix <> "gauge") mempty) "" (pure 0)
+          , registerHistogram (Identifier (prefix <> "histogram") mempty) "" (pure emptyHistogramSample)
+          , flip registerGroup (pure ()) $ Sample.fromList
+              [ (prefix <> "groupMetric", HM.singleton (prefix <> "counter") mempty, "", const (Counter 0))
+              , (prefix <> "groupMetric", HM.singleton (prefix <> "gauge") mempty, "", const (Gauge 0))
+              ]
+          ]
+
+  registerPermanently store $ registration "p"
+  deregistrationHandle1 <- registerRemovably store $ registration "r"
+  deregistrationHandle2 <- registerRemovablyCatch store $ registration "rc"
 
   !_ <- sampleAll store
 
-  deregistrationHandle
+  deregistrationHandle1
+  case deregistrationHandle2 of
+    Left _ -> pure ()
+    Right deregister -> deregister
+
+emptyHistogramSample :: HistogramSample
+emptyHistogramSample = HistogramSample
+  { histBuckets = Map.empty
+  , histSum = 0
+  , histCount = 0
+  }
 
 -- | Basic test of the store's input validation.
 test_validation :: IO ()
 test_validation = do
+  let registerSomething :: Store -> Text -> Text -> Text -> IO ()
+      registerSomething store metricName helpText labelName =
+        void $
+          registerRemovably store $
+            let identifier =
+                  Identifier metricName (HM.singleton labelName "labelValue")
+            in registerCounter identifier helpText (pure 0)
   store <- newStore
 
   registerSomething store "validMetricName" "validHelpText" "validLabelName"
   -- should not throw an exception
 
   registerSomething store "0invalidMetricName" "validHelpText" "validLabelName"
-    `shouldThrow` \case InvalidMetricName _ -> True; _ -> False
+    `shouldThrow` \case ValidationError (InvalidMetricName _) -> True; _ -> False
 
   registerSomething store "validMetricName" "invalidHelpText\\t" "validLabelName"
-    `shouldThrow` \case InvalidHelpText _ -> True; _ -> False
+    `shouldThrow` \case ValidationError (InvalidHelpText _) -> True; _ -> False
 
   registerSomething store "validMetricName" "validHelpText" "\"invalidLabelName"
-    `shouldThrow` \case InvalidLabelName _ -> True; _ -> False
+    `shouldThrow` \case ValidationError (InvalidLabelName _) -> True; _ -> False
 
-registerSomething :: Store -> Text -> Text -> Text -> IO ()
-registerSomething store metricName helpText labelName =
-  void $
-    register store $
-      let identifier =
-            Identifier metricName (HM.singleton labelName "labelValue")
-      in registerCounter identifier helpText (pure 0)
+test_permanentAndRemovableMetrics :: Spec
+test_permanentAndRemovableMetrics = do
+  let registerThing =
+        registerCounter (Identifier "name" HM.empty) "help" (pure 0)
+  it "Permanent metrics conflict with themselves" $ do
+    let permanentPermanent = do
+          store <- newStore
+          registerPermanently store registerThing
+          registerPermanently store registerThing
+    permanentPermanent `shouldThrow`
+      \case MetricIdentifierAlreadyUsed{} -> True; _ -> False
+
+  it "Permanent metrics conflict with removable metrics" $ do
+    let permanentRemovable = do
+          store <- newStore
+          registerPermanently store registerThing
+          _ <- registerRemovably store registerThing
+          pure ()
+    permanentRemovable `shouldThrow`
+      \case MetricIdentifierAlreadyUsed{} -> True; _ -> False
+
+    do
+      -- should not throw an exception
+      store <- newStore
+      registerPermanently store registerThing
+      Left (MetricIdentifierAlreadyUsed{}) <-
+        registerRemovablyCatch store registerThing
+      pure ()
+
+    let removablePermanent = do
+          store <- newStore
+          _ <- registerRemovably store registerThing
+          registerPermanently store registerThing
+    removablePermanent `shouldThrow`
+      \case MetricIdentifierAlreadyUsed{} -> True; _ -> False
+
+  it "Removable metrics do not conflict" $ do
+    -- should not throw an exception
+    store <- newStore
+    _ <- registerRemovably store $
+      registerCounter (Identifier "name" HM.empty) "help" (pure 0)
+    _ <- registerRemovably store $
+      registerCounter (Identifier "name" HM.empty) "help" (pure 0)
+    pure ()


### PR DESCRIPTION
This PR adds functionality for preventing metrics from being registered to the same metric identifier (name + labels).

### Motivation

[Each line [of the Prometheus exposition format] must have a unique combination of a metric name and labels](https://prometheus.io/docs/instrumenting/exposition_formats/#grouping-and-sorting), so we can only export at most one metric for each identifier. This currently enforced by only allowing one metric per identifier to be registered to the store. If a new metric is registered at the same identifier as an existing metric, the new metric replaces the existing metric.

This policy of always replacing metrics in cases of identifier collisions is necessary to prevent race conditions between registering and deregistering metrics, but it silences errors where multiple metrics are unintentionally registered to the same identifier. In such cases, the samples for all but one of the colliding metrics will be silently omitted from the metrics exposition.

### Implementation

This PR adds a "mutability" attribute to each metric, where each metric is registered as either "permanent" or "removable". "Removable" metrics correspond to the metrics as they are currently: they can be removed or replaced after being registered; the new "permanent" metrics cannot. The permanence of these metrics is enforced by throwing an exception during registration whenever there is a collision of identifiers involving at least one permanent metric. No exceptions are thrown for collisions of removable metrics.

The mutability of metrics is specified using new variants of the `register` function: `registerPermanently`, `registerRemovably`, and `registerRemovablyCatch`. The `register` function itself has been removed.

The convenience functions (e.g. `createCounter`) have been set to register their metrics permanently. This has been done because I expect most metrics to be registered as permanent metrics.

### Design

The behaviour of throwing exceptions to enforce the permanence of metrics is also used in the `ekg-core` and the `prometheus` Hackage packages.